### PR TITLE
Change all lighting effects to use sprites + shaders

### DIFF
--- a/SCENES/GUI/main_menu.tscn
+++ b/SCENES/GUI/main_menu.tscn
@@ -1,10 +1,13 @@
-[gd_scene load_steps=7 format=3 uid="uid://k7ghjsy8g1k0"]
+[gd_scene load_steps=16 format=3 uid="uid://k7ghjsy8g1k0"]
 
 [ext_resource type="Script" path="res://SCRIPTS/main_menu.gd" id="1_vkagb"]
 [ext_resource type="StyleBox" uid="uid://1mss4twkxib3" path="res://button_box.tres" id="2_y3ir5"]
 [ext_resource type="FontFile" uid="uid://di1ynwh6doxnf" path="res://ASSETS/Font/m5x7.ttf" id="3_mnfv6"]
 [ext_resource type="PackedScene" uid="uid://b7600w3ihvnlg" path="res://SCENES/MainMenu_tilemap_background.tscn" id="3_npyma"]
 [ext_resource type="PackedScene" uid="uid://dtrxpwxa5y3r" path="res://SCENES/firefly.tscn" id="5_wju8h"]
+[ext_resource type="Texture2D" uid="uid://w1hpwnxyhxto" path="res://SCENES/passive_light.tres" id="6_3lo0l"]
+[ext_resource type="Shader" path="res://light.gdshader" id="6_4j71s"]
+[ext_resource type="Shader" path="res://world_light.gdshader" id="7_08fn7"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_nqa2c"]
 font = ExtResource("3_mnfv6")
@@ -15,6 +18,33 @@ outline_color = Color(0.231373, 0.180392, 0.376471, 1)
 shadow_size = 20
 shadow_color = Color(0.172549, 0.133333, 0.278431, 0.643137)
 shadow_offset = Vector2(10, 10)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_31ixc"]
+shader = ExtResource("6_4j71s")
+shader_parameter/modulate = 1.0
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_8lnph"]
+shader = ExtResource("6_4j71s")
+shader_parameter/modulate = 1.0
+
+[sub_resource type="Gradient" id="Gradient_xlx5v"]
+offsets = PackedFloat32Array(0.457143, 1)
+colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 0)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_uyl3k"]
+gradient = SubResource("Gradient_xlx5v")
+width = 256
+height = 512
+fill = 1
+fill_from = Vector2(0.521368, 0.405983)
+fill_to = Vector2(0.487179, 0)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_5l7l8"]
+shader = ExtResource("7_08fn7")
+shader_parameter/world_light_color = Color(0, 0, 0, 1)
+
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_nwgo6"]
+size = Vector2(5000, 4000)
 
 [node name="MainMenu" type="Control"]
 custom_minimum_size = Vector2(640, 360)
@@ -65,6 +95,12 @@ theme_override_fonts/font = ExtResource("3_mnfv6")
 theme_override_font_sizes/font_size = 50
 theme_override_styles/normal = ExtResource("2_y3ir5")
 text = "Play"
+
+[node name="PassiveLightSprite" type="Sprite2D" parent="MenuContent/MenuButtons/PlayButton"]
+z_index = 12
+material = SubResource("ShaderMaterial_31ixc")
+position = Vector2(50, 21)
+texture = ExtResource("6_3lo0l")
 
 [node name="ControlsButton" type="Button" parent="MenuContent/MenuButtons"]
 visible = false
@@ -118,6 +154,20 @@ scale = Vector2(1, 1)
 position = Vector2(1583, 691)
 rotation = -1.69297
 scale = Vector2(1, 1)
+
+[node name="ActiveLightSprite" type="Sprite2D" parent="MenuContent"]
+z_index = 11
+material = SubResource("ShaderMaterial_8lnph")
+position = Vector2(748, 513)
+rotation = 1.5708
+scale = Vector2(-2.47459, 4.11177)
+texture = SubResource("GradientTexture2D_uyl3k")
+
+[node name="WorldLightSprite" type="Sprite2D" parent="."]
+z_index = 10
+material = SubResource("ShaderMaterial_5l7l8")
+position = Vector2(1352, 1227)
+texture = SubResource("PlaceholderTexture2D_nwgo6")
 
 [connection signal="pressed" from="MenuContent/MenuButtons/PlayButton" to="." method="_on_play_button_pressed"]
 [connection signal="pressed" from="MenuContent/MenuButtons/ControlsButton" to="." method="_on_controls_button_pressed"]

--- a/SCENES/firefly.tscn
+++ b/SCENES/firefly.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=12 format=3 uid="uid://dtrxpwxa5y3r"]
+[gd_scene load_steps=13 format=3 uid="uid://dtrxpwxa5y3r"]
 
 [ext_resource type="Script" path="res://SCRIPTS/firefly.gd" id="1_5j5rq"]
 [ext_resource type="Texture2D" uid="uid://beb2ya8fefyvb" path="res://ASSETS/Art/firefly.png" id="1_bpeie"]
+[ext_resource type="Texture2D" uid="uid://kpubr7xupcwj" path="res://SCENES/firefly_light_texture.tres" id="3_qcv6b"]
+[ext_resource type="Shader" path="res://light.gdshader" id="4_wffx1"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_rfwnd"]
 atlas = ExtResource("1_bpeie")
@@ -25,17 +27,9 @@ animations = [{
 "speed": 8.0
 }]
 
-[sub_resource type="Gradient" id="Gradient_axqho"]
-interpolation_mode = 2
-colors = PackedColorArray(1, 1, 1, 1, 0, 0, 0, 1)
-
-[sub_resource type="GradientTexture2D" id="GradientTexture2D_rrrod"]
-gradient = SubResource("Gradient_axqho")
-width = 128
-height = 128
-fill = 1
-fill_from = Vector2(0.5, 0.5)
-fill_to = Vector2(1, 0.5)
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_xk4u7"]
+shader = ExtResource("4_wffx1")
+shader_parameter/modulate = 1.0
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_1ii0q"]
 radius = 48.0
@@ -85,8 +79,7 @@ scale = Vector2(0.5, 0.5)
 script = ExtResource("1_5j5rq")
 
 [node name="Node2D" type="Node2D" parent="."]
-position = Vector2(112.093, -56.0465)
-rotation = 1.14327
+rotation = 0.466003
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="Node2D"]
 sprite_frames = SubResource("SpriteFrames_dg7is")
@@ -94,10 +87,17 @@ autoplay = "default"
 frame_progress = 0.598393
 
 [node name="PointLight2D" type="PointLight2D" parent="Node2D"]
+visible = false
 position = Vector2(0, 29)
 color = Color(0.980392, 0.835294, 0.329412, 1)
 energy = 0.5
-texture = SubResource("GradientTexture2D_rrrod")
+texture = ExtResource("3_qcv6b")
+
+[node name="Sprite2D" type="Sprite2D" parent="Node2D"]
+z_index = 11
+material = SubResource("ShaderMaterial_xk4u7")
+position = Vector2(0, 29)
+texture = ExtResource("3_qcv6b")
 
 [node name="Area2D" type="Area2D" parent="Node2D"]
 position = Vector2(0, 29)

--- a/SCENES/firefly_light_texture.tres
+++ b/SCENES/firefly_light_texture.tres
@@ -1,0 +1,13 @@
+[gd_resource type="GradientTexture2D" load_steps=2 format=3 uid="uid://kpubr7xupcwj"]
+
+[sub_resource type="Gradient" id="Gradient_axqho"]
+interpolation_mode = 2
+colors = PackedColorArray(0.980392, 0.835294, 0.329412, 1, 1, 1, 1, 0)
+
+[resource]
+gradient = SubResource("Gradient_axqho")
+width = 128
+height = 128
+fill = 1
+fill_from = Vector2(0.5, 0.5)
+fill_to = Vector2(1, 0.5)

--- a/SCENES/passive_light.tres
+++ b/SCENES/passive_light.tres
@@ -1,0 +1,13 @@
+[gd_resource type="GradientTexture2D" load_steps=2 format=3 uid="uid://w1hpwnxyhxto"]
+
+[sub_resource type="Gradient" id="Gradient_5jo1n"]
+offsets = PackedFloat32Array(0.235714, 1)
+colors = PackedColorArray(0.403922, 0.807843, 0.654902, 1, 1, 1, 1, 0)
+
+[resource]
+gradient = SubResource("Gradient_5jo1n")
+width = 256
+height = 256
+fill = 1
+fill_from = Vector2(0.5, 0.5)
+fill_to = Vector2(0, 0.5)

--- a/SCENES/playground.tscn
+++ b/SCENES/playground.tscn
@@ -1,21 +1,36 @@
-[gd_scene load_steps=8 format=3 uid="uid://dhvgc0glasyim"]
+[gd_scene load_steps=12 format=3 uid="uid://dhvgc0glasyim"]
 
 [ext_resource type="Script" path="res://SCRIPTS/playground.gd" id="1_5e8d0"]
 [ext_resource type="PackedScene" uid="uid://b3pegdwcapkhe" path="res://SCENES/tilemap_background.tscn" id="2_fetls"]
+[ext_resource type="Shader" path="res://world_light.gdshader" id="2_k1kh8"]
 [ext_resource type="PackedScene" uid="uid://do6vv53psm4aw" path="res://SCENES/player.tscn" id="3_7v63e"]
 [ext_resource type="PackedScene" uid="uid://ctedc5thhssj2" path="res://SCENES/frog.tscn" id="4_vxm8d"]
 [ext_resource type="PackedScene" uid="uid://dtrxpwxa5y3r" path="res://SCENES/firefly.tscn" id="5_svg8i"]
 [ext_resource type="PackedScene" uid="uid://b77mh17y84d50" path="res://SCENES/GUI/mobile_controls.tscn" id="7_uhrci"]
 [ext_resource type="PackedScene" uid="uid://bvp1lppkqj5qi" path="res://SCENES/GUI/level_ui.tscn" id="8_y8n3e"]
 
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_mwxo7"]
+shader = ExtResource("2_k1kh8")
+shader_parameter/world_light_color = Color(0, 0, 0, 0.901961)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_kkt2g"]
+shader = ExtResource("2_k1kh8")
+shader_parameter/world_light_color = Color(0, 0, 0, 1)
+
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_ikir6"]
+size = Vector2(5000, 4000)
+
 [node name="Playground" type="Node" node_paths=PackedStringArray("mobile_controls")]
 script = ExtResource("1_5e8d0")
 mobile_controls = NodePath("MobileControls")
 
 [node name="WorldModulate" type="CanvasModulate" parent="."]
-color = Color(0, 0, 0, 1)
+visible = false
+z_index = 100
+material = SubResource("ShaderMaterial_mwxo7")
 
 [node name="WorldLight" type="DirectionalLight2D" parent="."]
+visible = false
 energy = 0.1
 
 [node name="TileMapBackground" parent="." instance=ExtResource("2_fetls")]
@@ -102,4 +117,8 @@ rotation = -0.459022
 
 [node name="LevelUI" parent="." instance=ExtResource("8_y8n3e")]
 
-[node name="Node2D" type="Node2D" parent="."]
+[node name="WorldLightSprite" type="Sprite2D" parent="."]
+z_index = 10
+material = SubResource("ShaderMaterial_kkt2g")
+position = Vector2(1352, 1227)
+texture = SubResource("PlaceholderTexture2D_ikir6")

--- a/SCENES/staff.tscn
+++ b/SCENES/staff.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=12 format=4 uid="uid://vgklta6kvogj"]
+[gd_scene load_steps=14 format=4 uid="uid://vgklta6kvogj"]
 
 [ext_resource type="Script" path="res://SCRIPTS/staff.gd" id="1_l6354"]
 [ext_resource type="Texture2D" uid="uid://b4n6irf1jephl" path="res://icon.svg" id="1_qdlpt"]
 [ext_resource type="Texture2D" uid="uid://chame0653mo4c" path="res://ASSETS/Art/staff.png" id="1_sswp8"]
 [ext_resource type="Texture2D" uid="uid://d0ndhw46d2s4r" path="res://SCENES/active_light_texture.tres" id="4_360uc"]
+[ext_resource type="Texture2D" uid="uid://w1hpwnxyhxto" path="res://SCENES/passive_light.tres" id="4_ggqr7"]
+[ext_resource type="Shader" path="res://light.gdshader" id="5_6bqmo"]
 [ext_resource type="AudioStream" uid="uid://b5fep0qqjvstp" path="res://ASSETS/Audio/staff_active.ogg" id="5_h5ium"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_y5hcc"]
@@ -76,22 +78,19 @@ texture = ExtResource("1_qdlpt")
 [sub_resource type="TileSet" id="TileSet_3jiyq"]
 sources/0 = SubResource("TileSetAtlasSource_y5hcc")
 
-[sub_resource type="Gradient" id="Gradient_5jo1n"]
-colors = PackedColorArray(1, 1, 1, 1, 0, 0, 0, 1)
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_sejfs"]
+shader = ExtResource("5_6bqmo")
+shader_parameter/modulate = 1.0
 
-[sub_resource type="GradientTexture2D" id="GradientTexture2D_p4ihi"]
-gradient = SubResource("Gradient_5jo1n")
-width = 256
-height = 256
-fill = 1
-fill_from = Vector2(0.5, 0.5)
-fill_to = Vector2(0, 0.5)
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_nr7np"]
+shader = ExtResource("5_6bqmo")
+shader_parameter/modulate = 1.0
 
-[sub_resource type="Gradient" id="Gradient_xlx5v"]
-colors = PackedColorArray(1, 1, 1, 1, 0, 0, 0, 0)
+[sub_resource type="Gradient" id="Gradient_2v4ng"]
+colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 0)
 
 [sub_resource type="GradientTexture2D" id="GradientTexture2D_hdb2i"]
-gradient = SubResource("Gradient_xlx5v")
+gradient = SubResource("Gradient_2v4ng")
 width = 256
 height = 512
 fill = 1
@@ -115,24 +114,33 @@ light_mask = 3
 texture = ExtResource("1_sswp8")
 
 [node name="PassiveLight" type="PointLight2D" parent="."]
+visible = false
 position = Vector2(9, -20)
 color = Color(0.403922, 0.807843, 0.654902, 1)
 range_item_cull_mask = 2
-texture = SubResource("GradientTexture2D_p4ihi")
+texture = ExtResource("4_ggqr7")
+
+[node name="PassiveLightSprite" type="Sprite2D" parent="."]
+z_index = 12
+material = SubResource("ShaderMaterial_sejfs")
+position = Vector2(9, -20)
+texture = ExtResource("4_ggqr7")
 
 [node name="ActiveLightArea" type="Area2D" parent="."]
 collision_layer = 0
 collision_mask = 4
 
 [node name="ActiveLight" type="PointLight2D" parent="ActiveLightArea"]
+visible = false
 position = Vector2(-75, -106)
 rotation = -0.654362
 shadow_item_cull_mask = 2
 texture = ExtResource("4_360uc")
 texture_scale = 1.5
 
-[node name="Sprite2D" type="Sprite2D" parent="ActiveLightArea"]
-visible = false
+[node name="ActiveLightSprite" type="Sprite2D" parent="ActiveLightArea"]
+z_index = 11
+material = SubResource("ShaderMaterial_nr7np")
 position = Vector2(-75, -106)
 rotation = -0.654498
 scale = Vector2(1.5, 1.5)

--- a/SCRIPTS/staff.gd
+++ b/SCRIPTS/staff.gd
@@ -2,27 +2,31 @@ extends Node2D
 
 class_name Staff
 
-@onready var active_light: PointLight2D = $ActiveLightArea/ActiveLight
+@onready var active_light: Sprite2D = $ActiveLightArea/ActiveLightSprite
 @onready var active_area: CollisionPolygon2D = $ActiveLightArea/CollisionPolygon2D
-@onready var passive_light: PointLight2D = $PassiveLight
+@onready var passive_light: Sprite2D = $PassiveLightSprite
 @onready var active_sound: AudioStreamPlayer = $ActiveSound
+@onready var tile_map_background: Node2D = $TileMapBackground
+
 
 const energy_use_per_second = .3
+var energy = 1.0
 
 var active := false
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass # Replace with function body.
+	tile_map_background.hide()
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
 	var energy_mod = 2.0
 	if active:
 		energy_mod = -1.0
-	passive_light.energy = clamp(passive_light.energy + delta * energy_mod * energy_use_per_second, 0.0, 1.0)
-	active_light.energy = passive_light.energy
-	active_light.visible = active and passive_light.energy > 0.0
+	energy = clamp(energy + delta * energy_mod * energy_use_per_second, 0.0, 1.0)
+	active_light.material.set_shader_parameter("modulate", energy)
+	passive_light.material.set_shader_parameter("modulate", energy)
+	active_light.visible = active and energy > 0.0
 	active_area.disabled = not active_light.visible
 	if active_sound.playing != active_light.visible:
 		active_sound.playing = active_light.visible

--- a/light.gdshader
+++ b/light.gdshader
@@ -1,0 +1,22 @@
+shader_type canvas_item;
+
+uniform sampler2D screen_texture: hint_screen_texture, repeat_disable, filter_nearest;
+uniform float modulate = 1.0;
+
+void vertex() {
+	// Called for every vertex the material is visible on.
+}
+
+void fragment() {
+	vec4 screen_color = texture(screen_texture, SCREEN_UV);
+	vec4 texture_color = texture(TEXTURE, UV);
+	if(texture_color.a > 0.0){
+		COLOR = screen_color * texture_color;
+		COLOR.a *= modulate;
+	}
+}
+
+//void light() {
+	// Called for every pixel for every light affecting the CanvasItem.
+	// Uncomment to replace the default light processing function with this one.
+//}

--- a/world_light.gdshader
+++ b/world_light.gdshader
@@ -1,0 +1,18 @@
+shader_type canvas_item;
+
+uniform sampler2D screen_texture: hint_screen_texture, repeat_disable, filter_nearest;
+uniform vec4 world_light_color: source_color;
+
+void vertex() {
+	// Called for every vertex the material is visible on.
+}
+
+void fragment() {
+	vec4 screen_color = texture(screen_texture, SCREEN_UV);
+	COLOR = mix(screen_color, world_light_color, .9);
+}
+
+//void light() {
+	// Called for every pixel for every light affecting the CanvasItem.
+	// Uncomment to replace the default light processing function with this one.
+//}


### PR DESCRIPTION
Since this prototype doesn't really need actual light2d nodes, decided to redo them as sprites with shaders to allow for better performance on mobile